### PR TITLE
Remove French from the language selector

### DIFF
--- a/TheConsultancyFirm/Views/Shared/HeaderPartial.cshtml
+++ b/TheConsultancyFirm/Views/Shared/HeaderPartial.cshtml
@@ -14,7 +14,6 @@
         <div class="collapse navbar-collapse" id="navbarContent">
             <ul class="lang-select">
                 <li><a href="#">English</a></li>
-                <li><a href="#">French</a></li>
             </ul>
 
             <div class="navbar-content">


### PR DESCRIPTION
This only removes the option to select french as a language as it was requested to stop that feature completely.