### PR TITLE
Focus input on opening search form, use GET for search form

### DIFF
--- a/TheConsultancyFirm/Controllers/SearchController.cs
+++ b/TheConsultancyFirm/Controllers/SearchController.cs
@@ -11,9 +11,9 @@ namespace TheConsultancyFirm.Controllers
     public class SearchController : Controller
     {
         // GET: /<controller>/
-        public IActionResult Index(string search)
+        public IActionResult Index(string q)
         {
-            ViewBag.Search = search;
+            ViewBag.Search = q;
 
             //Todo Model stuff. Get all cases, news and downloads wich contains the search keyword.
 

--- a/TheConsultancyFirm/Styles/pages/_search.scss
+++ b/TheConsultancyFirm/Styles/pages/_search.scss
@@ -13,14 +13,9 @@
         padding: 10px;
         border: none;
 
-        &:hover::placeholder,
         &:focus::placeholder,
         &:active::placeholder {
             color: transparent;
-        }
-
-        &:hover {
-            cursor: pointer;
         }
 
         &:focus {

--- a/TheConsultancyFirm/Styles/partials/_header.scss
+++ b/TheConsultancyFirm/Styles/partials/_header.scss
@@ -220,6 +220,7 @@ header {
             width: 0 !important;
             transition: all .3s ease-in-out;
             margin-right: 0 !important;
+            padding: 8px 0 7px;
         }
 
         &.open {
@@ -229,7 +230,7 @@ header {
 
             input {
                 width: 377px !important;
-                padding-right: 30px !important;
+                padding: 8px 12px 7px;
             }
 
             .fa-times {

--- a/TheConsultancyFirm/Views/Search/Index.cshtml
+++ b/TheConsultancyFirm/Views/Search/Index.cshtml
@@ -14,9 +14,9 @@
         <p class="col d-flex justify-content-center">Er zijn 666 zoekresultaten voor de term: "@ViewBag.Search"</p>
     </div>
     <div class="row">
-        <form class="search-form">
+        <form asp-action="Index" class="search-form" method="get">
             <div class="search-container">
-                <input placeholder="Nieuwe zoekterm" type="search" name="search" />
+                <input placeholder="Nieuwe zoekterm" type="search" name="q" value="@ViewBag.Search" />
                 <button type="submit">
                     <i class="fa fa-search"></i>
                 </button>

--- a/TheConsultancyFirm/Views/Shared/HeaderPartial.cshtml
+++ b/TheConsultancyFirm/Views/Shared/HeaderPartial.cshtml
@@ -40,13 +40,13 @@
                     </li>
                 </ul>
 
-                <form asp-controller="Search" asp-action="Index" class="form-inline my-2 my-lg-0 mx-3 search">
+                <form asp-controller="Search" asp-action="Index" class="form-inline my-2 my-lg-0 mx-3 search" method="get">
                     <div class="searchbox">
-                        <input class="form-control mr-sm-2" type="search" name="search" placeholder="Nieuwe zoekterm">
+                        <input class="form-control mr-sm-2" type="search" name="q" placeholder="Nieuwe zoekterm" tabindex="-1">
                         <i class="fa fa-times"></i>
                     </div>
 
-                    <button class="my-2 my-sm-0" type="submit">
+                    <button class="my-2 my-sm-0" type="submit" tabindex="-1">
                         <i class="fa fa-search"></i>
                     </button>
                 </form>

--- a/TheConsultancyFirm/wwwroot/js/navbar.js
+++ b/TheConsultancyFirm/wwwroot/js/navbar.js
@@ -17,6 +17,7 @@ jQuery(function ($) {
         // Open search form but don't submit when the searchform is closed
         e.preventDefault();
         $searchform.toggleClass('open');
+        $searchform.find('input').focus();
         $navbar.find('.navbar-collapse').removeClass('open');
     });
 


### PR DESCRIPTION
When clicking the search icon in the header, also focus the search input so we can directly type into it.

Also changes the search forms to use GET requests so we can share links with the search query in it.
Renamed search parameter to q (query) as `/search?search=` is weird.
Use default text editing cursor for search input field and stop hiding placeholder on hover.
Fix search input height.