### PR TITLE
Use mime guessing to find the file mime type instead of trusting the file extension

### DIFF
--- a/TheConsultancyFirm/Areas/Dashboard/Controllers/CasesController.cs
+++ b/TheConsultancyFirm/Areas/Dashboard/Controllers/CasesController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using HeyRed.Mime;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -55,8 +56,12 @@ namespace TheConsultancyFirm.Areas.Dashboard.Controllers
                 ModelState.AddModelError(nameof(@case.Image), "The Image field is required.");
             else
             {
-                if (!(new[] {".png", ".jpg", ".jpeg"}).Contains(Path.GetExtension(@case.Image.FileName)?.ToLower()))
-                    ModelState.AddModelError(nameof(@case.Image), "Invalid image type, only png and jpg images are allowed");
+                using (var stream = @case.Image.OpenReadStream())
+                {
+                    if (!(new[] {"image/png", "image/jpeg"}).Contains(MimeGuesser.GuessMimeType(stream)))
+                        ModelState.AddModelError(nameof(@case.Image),
+                            "Invalid image type, only png and jpg images are allowed");
+                }
 
                 if (@case.Image.Length < 1)
                     ModelState.AddModelError(nameof(@case.Image), "Filesize too small");
@@ -115,8 +120,12 @@ namespace TheConsultancyFirm.Areas.Dashboard.Controllers
 
             if (@case.Image != null)
             {
-                if (!(new[] {".png", ".jpg", ".jpeg"}).Contains(Path.GetExtension(@case.Image.FileName)?.ToLower()))
-                    ModelState.AddModelError(nameof(@case.Image), "Invalid image type, only png and jpg images are allowed");
+                using (var stream = @case.Image.OpenReadStream())
+                {
+                    if (!(new[] {"image/png", "image/jpeg"}).Contains(MimeGuesser.GuessMimeType(stream)))
+                        ModelState.AddModelError(nameof(@case.Image),
+                            "Invalid image type, only png and jpg images are allowed");
+                }
 
                 if (@case.Image.Length == 0)
                     ModelState.AddModelError(nameof(@case.Image), "Filesize too small");

--- a/TheConsultancyFirm/Areas/Dashboard/Controllers/CustomersController.cs
+++ b/TheConsultancyFirm/Areas/Dashboard/Controllers/CustomersController.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using HeyRed.Mime;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TheConsultancyFirm.Models;
@@ -70,8 +71,12 @@ namespace TheConsultancyFirm.Areas.Dashboard.Controllers
                 ModelState.AddModelError(nameof(customer.Image), "The Image field is required.");
             else
             {
-                if (!(new[] {".png", ".jpg", ".jpeg"}).Contains(Path.GetExtension(customer.Image.FileName)?.ToLower()))
-                    ModelState.AddModelError(nameof(customer.Image), "Invalid image type, only png and jpg images are allowed");
+                using (var stream = customer.Image.OpenReadStream())
+                {
+                    if (!(new[] {"image/png", "image/jpeg"}).Contains(MimeGuesser.GuessMimeType(stream)))
+                        ModelState.AddModelError(nameof(customer.Image),
+                            "Invalid image type, only png and jpg images are allowed");
+                }
 
                 if (customer.Image.Length < 1)
                     ModelState.AddModelError(nameof(customer.Image), "Filesize too small");
@@ -117,8 +122,12 @@ namespace TheConsultancyFirm.Areas.Dashboard.Controllers
 
             if (customer.Image != null)
             {
-                if (!(new[] {".png", ".jpg", ".jpeg"}).Contains(Path.GetExtension(customer.Image.FileName)?.ToLower()))
-                    ModelState.AddModelError(nameof(customer.Image), "Invalid image type, only png and jpg images are allowed");
+                using (var stream = customer.Image.OpenReadStream())
+                {
+                    if (!(new[] {"image/png", "image/jpeg"}).Contains(MimeGuesser.GuessMimeType(stream)))
+                        ModelState.AddModelError(nameof(customer.Image),
+                            "Invalid image type, only png and jpg images are allowed");
+                }
 
                 if (customer.Image.Length == 0)
                     ModelState.AddModelError(nameof(customer.Image), "Filesize too small");

--- a/TheConsultancyFirm/TheConsultancyFirm.csproj
+++ b/TheConsultancyFirm/TheConsultancyFirm.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.1" />
+    <PackageReference Include="Mime" Version="3.0.0" />
     <PackageReference Include="Unidecode.NET" Version="1.1.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Validate image type based on guessed mime type instead of filename extension.

Mime type is guessed based on the first few bytes of the uploaded file.